### PR TITLE
Adds `com.compuserve.gif` file descriptor

### DIFF
--- a/app/src/lib/photos-library/model/file-type.ts
+++ b/app/src/lib/photos-library/model/file-type.ts
@@ -9,6 +9,7 @@ const EXT = {
     'com.apple.quicktime-movie': `mov`,
     'public.heic': `heic`,
     'com.sony.arw-raw-image': `arw`,
+    'com.compuserve.gif': `gif`,
 };
 
 /**


### PR DESCRIPTION
While using the CLI, I received the following message from the tool:

```log
[2022-12-20T20:24:15.164Z] WARN Sync-Engine: Unrecoverable sync error: Unknown filetype descriptor: com.compuserve.gif
```

<img width="940" alt="image" src="https://user-images.githubusercontent.com/69803/208760389-b13cf1dc-6f0d-4f90-a752-dd5f9c794a84.png">

This PR fixes that.