### PR TITLE
local-file-structure.md: add newline before list

### DIFF
--- a/pages/docs/dev/local-file-structure.md
+++ b/pages/docs/dev/local-file-structure.md
@@ -3,6 +3,7 @@ This documentation describes the local file structure, that is written by this a
 
 ## Root folder
 The root folder is specified through environment variable `DATA_DIR`. All assets and information are stored here:
+
   * `_All-Photos` Folder (aka. `ASSET_DIR`, [see src](https://github.com/steilerDev/icloud-photos-sync/blob/main/app/src/lib/photos-library/constants.ts))
   * `_Archive` Folder (aka. `ARCHIVE_DIR`, [see src](https://github.com/steilerDev/icloud-photos-sync/blob/main/app/src/lib/photos-library/constants.ts))
   * `.icloud-photos-sync.log`: Log file, overwritten upon application restart
@@ -19,6 +20,7 @@ If an archived folder is deleted in the iCloud backend, this folder will be move
 
 ### User Folders
 Every user folder has two components:
+
   * A link with the display name of the folder/album, which links to
   * A folder containing the data, named after the UUID of the folder (and hidden: `.{UUID}`)
 


### PR DESCRIPTION
If this newline is omitted, no HTML `<ul>` is created. The markdown renderer appears to treat it as a continuation of the paragraph before, and therefore inlines it:

<img width="717" alt="Screenshot 2023-02-05 at 9 29 31 PM" src="https://user-images.githubusercontent.com/237985/216891004-4df0b5d6-09df-4edc-a93e-65fa25478a65.png">
