### PR TITLE
fix Maximum call stack size exceeded issue

### DIFF
--- a/app/src/lib/icloud/icloud-photos/icloud-photos.ts
+++ b/app/src/lib/icloud/icloud-photos/icloud-photos.ts
@@ -538,7 +538,7 @@ export class iCloudPhotos extends EventEmitter {
             if (this.auth.sharedLibraryAvailable()) {
                 this.logger.debug(`Fetching all picture records for album ${parentId === undefined ? `All photos` : parentId} for shared zone`);
                 const [sharedRecords, sharedExpectedCount] = await this.fetchAllPictureRecordsForZone(QueryBuilder.Zones.Shared);
-                allRecords.push(...sharedRecords);
+                allRecords = [...allRecords, ...sharedRecords];
                 expectedNumberOfRecords += sharedExpectedCount;
             }
         } catch (err) {

--- a/app/src/lib/icloud/icloud-photos/icloud-photos.ts
+++ b/app/src/lib/icloud/icloud-photos/icloud-photos.ts
@@ -535,7 +535,8 @@ export class iCloudPhotos extends EventEmitter {
             [allRecords, expectedNumberOfRecords] = await this.fetchAllPictureRecordsForZone(QueryBuilder.Zones.Primary, parentId);
 
             // Merging assets of shared library, if available
-            if (this.auth.sharedLibraryAvailable()) {
+            if (this.auth.sharedLibraryAvailable() && typeof parentId === 'undefined') {
+                // only fetch shared album records if no parentId is specified, since icloud api does not yet support shared records in albums
                 this.logger.debug(`Fetching all picture records for album ${parentId === undefined ? `All photos` : parentId} for shared zone`);
                 const [sharedRecords, sharedExpectedCount] = await this.fetchAllPictureRecordsForZone(QueryBuilder.Zones.Shared);
                 allRecords = [...allRecords, ...sharedRecords];

--- a/app/src/lib/photos-library/model/file-type.ts
+++ b/app/src/lib/photos-library/model/file-type.ts
@@ -35,6 +35,7 @@ const EXT = {
     'com.nikon.raw-image': `nef`,
     'com.olympus.raw-image': `orf`,
     'public.avi': `avi`,
+    'com.adobe.pdf': `pdf`,
 };
 
 /**

--- a/app/test/unit/photos-library.test.ts
+++ b/app/test/unit/photos-library.test.ts
@@ -122,7 +122,7 @@ describe(`Load state`, () => {
                         "Aa7_yox97ecSUNmVw0xP4YzIDDKf.jpeg": Buffer.from([1, 1, 1, 1]),
                         "AaGv15G3Cp9LPMQQfFZiHRryHgjU.jpeg": Buffer.from([1, 1, 1, 1, 1]),
                         "Aah0dUnhGFNWjAeqKEkB_SNLNpFf": Buffer.from([1, 1, 1, 1, 1, 1]), // No file extension
-                        "Aah0dUnhGFNWjAeqKEkB_SNLNpFf.pdf": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file extension
+                        "Aah0dUnhGFNWjAeqKEkB_SNLNpFf.xyz": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file extension
                         "Aah0dUnhGFNWjAeqKEkB_SNLNpF-f": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file name
                     },
                 },
@@ -135,7 +135,7 @@ describe(`Load state`, () => {
                         "Aa7_yox97ecSUNmVw0xP4YzIDDKf.jpeg": Buffer.from([1, 1, 1, 1]),
                         "AaGv15G3Cp9LPMQQfFZiHRryHgjU.jpeg": Buffer.from([1, 1, 1, 1, 1]),
                         "Aah0dUnhGFNWjAeqKEkB_SNLNpFf": Buffer.from([1, 1, 1, 1, 1, 1]), // No file extension
-                        "Aah0dUnhGFNWjAeqKEkB_SNLNpFf.pdf": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file extension
+                        "Aah0dUnhGFNWjAeqKEkB_SNLNpFf.xyz": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file extension
                         "Aah0dUnhGFNWjAeqKEkB_SNLNpF-f": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file name
                     },
                 },
@@ -148,13 +148,13 @@ describe(`Load state`, () => {
                         "deFEyox97ecdknADe0xP4YzIDDKf.jpeg": Buffer.from([1, 1, 1, 1]),
                         "deFEeee3Cp9LPMQQfFZiHRryHgjU.jpeg": Buffer.from([1, 1, 1, 1, 1]),
                         "kkiceenhGFNWjAeqKEkB_SNLNpFf.jpeg": Buffer.from([1, 1, 1, 1, 1, 1]),
-                        "Aah0dUnasdfejAeqKEkB_SNLNpFf.pdf": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file extension
+                        "Aah0dUnasdfejAeqKEkB_SNLNpFf.xyz": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file extension
                     },
                     [sharedAssetDir]: {
                         "Aa7_yox97ecSUNmVw0xP4YzIDDKf.jpeg": Buffer.from([1, 1, 1, 1]),
                         "AaGv15G3Cp9LPMQQfFZiHRryHgjU.jpeg": Buffer.from([1, 1, 1, 1, 1]),
                         "Aah0dUnhGFNWjAeqKEkB_SNLNpFf": Buffer.from([1, 1, 1, 1, 1, 1]), // No file extension
-                        "Aah0dUnhGFNWjAeqKEkB_SNLNpFf.pdf": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file extension
+                        "Aah0dUnhGFNWjAeqKEkB_SNLNpFf.xyz": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file extension
                         "Aah0dUnhGFNWjAeqKEkB_SNLNpF-f": Buffer.from([1, 1, 1, 1, 1, 1]), // Invalid file name
                     },
                 },


### PR DESCRIPTION
This PR includes a fix for the [call stack issue](https://github.com/steilerDev/icloud-photos-sync/issues/230) I was having.

Surprisingly the problem was with this line of code in `icloud-photos`

```javascript
allRecords.push(...sharedRecords)
```

The problem manifested itself for me because my sharedRecords array has hundreds of thousands of assets in it.  And using the spread operator like this adds hundreds of thousands of items to the push method call's parameters list.  This overloads the stack and 😵.  You can read more about the issue [here](https://stackoverflow.com/questions/61740599/rangeerror-maximum-call-stack-size-exceeded-with-array-push).

We can instead re-create the `allRecords` array using the elements from both arrays like so:

```javascript
allRecords = [...allRecords, ...sharedRecords];
```
This avoids putting hundreds of thousands of records into the function's argument stack, while accomplishing the same result.

I also added a file type for `pdf`, since apparently i have PDFs in my iCloud photo library 🙃 . 