### PR TITLE
fix file diffing issue

### DIFF
--- a/app/src/lib/photos-library/model/asset.ts
+++ b/app/src/lib/photos-library/model/asset.ts
@@ -164,7 +164,7 @@ export class Asset implements PEntity<Asset> {
                 && this.fileChecksum === asset.fileChecksum
                 && this.fileType.equal(asset.fileType)
                 && this.size === asset.size
-                && this.withinRange(this.modified, asset.modified, 10);
+                && this.withinRange(this.modified, asset.modified, 1000);
     }
 
     /**

--- a/app/test/unit/sync-engine.test.ts
+++ b/app/test/unit/sync-engine.test.ts
@@ -515,8 +515,8 @@ describe(`Diffing state`, () => {
 
         test(`Only modified changed`, () => {
             const remoteAssets = [
-                new Asset(`somechecksum`, 42, FileType.fromExtension(`png`), 142, getRandomZone(), AssetType.ORIG, `test`, `somekey`, `somechecksum`, `https://icloud.com`, `somerecordname`, false),
-                new Asset(`somechecksum1`, 42, FileType.fromExtension(`png`), 142, getRandomZone(), AssetType.EDIT, `test1`, `somekey`, `somechecksum1`, `https://icloud.com`, `somerecordname1`, false),
+                new Asset(`somechecksum`, 42, FileType.fromExtension(`png`), 1420, getRandomZone(), AssetType.ORIG, `test`, `somekey`, `somechecksum`, `https://icloud.com`, `somerecordname`, false),
+                new Asset(`somechecksum1`, 42, FileType.fromExtension(`png`), 1420, getRandomZone(), AssetType.EDIT, `test1`, `somekey`, `somechecksum1`, `https://icloud.com`, `somerecordname1`, false),
                 new Asset(`somechecksum2`, 42, FileType.fromExtension(`png`), 42, getRandomZone(), AssetType.EDIT, `test2`, `somekey`, `somechecksum2`, `https://icloud.com`, `somerecordname2`, false),
                 new Asset(`somechecksum3`, 42, FileType.fromExtension(`png`), 42, getRandomZone(), AssetType.ORIG, `test3`, `somekey`, `somechecksum3`, `https://icloud.com`, `somerecordname3`, false),
             ];


### PR DESCRIPTION
I found that there was a significant amount of churn during sync.  for example, here is some data representing what happened during a routine sync:

```
remote entities		171,682


to be added			170,646
to be deleted		        82973
to be kept			1036
```

notice that 82,973 local entities are deleted and 170k added.  this seemed fishy to me, so I investigated.

It turns out that assets are compared to see if they are roughly equal.  Part of that is to check if the modified date is within close range.  It was using 10ms as wiggle room for the range.  But I saw elsewhere 1000ms is used.  I bumped the 10 to 1000 in the `equal` method of the asset class and it fixed the comparison problem i was having.  These are the results afterwards:

```
remote entities		171,682


to be added			87,674
to be deleted		1
to be kept			84008
```

