### PR TITLE
[WIP] Persist cookies to disk

### DIFF
--- a/app/src/lib/icloud/auth.ts
+++ b/app/src/lib/icloud/auth.ts
@@ -150,7 +150,7 @@ export class iCloudAuth {
             this.logger.trace(`  - token: ${serializedCookies}`);
 
             this.iCloudCookies = deserializeCookies(serializedCookies);
-            this.validateCloudCookies()
+            this.validateCloudCookies();
         } catch (err) {
             this.logger.debug(`Unable to load cookies from file: ${err.message}`);
         }
@@ -228,7 +228,7 @@ export class iCloudAuth {
      */
     getMFAHeaders(): any {
         this.validateAuthSecrets();
-        return {...ICLOUD.DEFAULT_AUTH_HEADER,
+        return {...this.getPhotosHeader(ICLOUD.DEFAULT_AUTH_HEADER),
             "scnt": this.iCloudAuthSecrets.scnt,
             'X-Apple-ID-Session-Id': this.iCloudAuthSecrets.sessionId,
             "Cookie": `aasp=${this.iCloudAuthSecrets.aasp}`,
@@ -300,8 +300,8 @@ export class iCloudAuth {
      * @returns A fully authenticated header, to be used with the iCloud Photos Service
      * @throws An iCloudAuthError in case the returned headers would be expired
      */
-    getPhotosHeader(): any {
-        return {...ICLOUD.DEFAULT_HEADER,
+    getPhotosHeader(baseHeader = ICLOUD.DEFAULT_HEADER): any {
+        return {...baseHeader,
             "Cookie": this.getCookiesHeaderString(),
         };
     }
@@ -313,15 +313,21 @@ export class iCloudAuth {
      */
     getCookiesHeaderString(): string {
         let cookieString: string = ``;
-        this.validateCloudCookies();
-        this.iCloudCookies.forEach(cookie => {
-            if (cookieString.length === 0) {
-                cookieString = cookie.cookieString();
-            } else {
-                cookieString = `${cookieString}; ${cookie.cookieString()}`;
-            }
-        });
-        this.logger.trace(`Build cookie string: ${cookieString}`);
+        try {
+            this.validateCloudCookies();
+
+            this.iCloudCookies.forEach(cookie => {
+                if (cookieString.length === 0) {
+                    cookieString = cookie.cookieString();
+                } else {
+                    cookieString = `${cookieString}; ${cookie.cookieString()}`;
+                }
+            });
+            this.logger.trace(`Build cookie string: ${cookieString}`);
+        } catch (err) {
+            this.logger.trace(err.message);
+        }
+
         return cookieString;
     }
 

--- a/app/src/lib/icloud/icloud.ts
+++ b/app/src/lib/icloud/icloud.ts
@@ -123,7 +123,7 @@ export class iCloud extends EventEmitter {
         this.auth.validateAccountSecrets();
 
         const config: AxiosRequestConfig = {
-            "headers": ICLOUD.DEFAULT_AUTH_HEADER,
+            "headers": {...this.auth.getPhotosHeader(ICLOUD.DEFAULT_AUTH_HEADER)},
             "params": {
                 "isRememberMeEnabled": true,
             },

--- a/app/src/lib/icloud/utils.ts
+++ b/app/src/lib/icloud/utils.ts
@@ -1,0 +1,20 @@
+import { Cookie } from "tough-cookie";
+
+export function sanitized(value: string): string {
+    return ["@", ".", "%"].reduce((result, forbiddenCharacter) => {
+        return result.replaceAll(forbiddenCharacter, "");
+    }, value);
+}
+
+export function serializeCookies(cookies: Array<Cookie> = []): string {
+    return JSON.stringify({
+        cookies: cookies.map((cookie) => cookie.toJSON()),
+    });
+}
+
+export function deserializeCookies(
+    serializedCookies: string = ""
+): Array<Cookie> {
+    const { cookies } = JSON.parse(serializedCookies);
+    return cookies.map((cookie) => Cookie.fromJSON(cookie));
+}

--- a/app/test/unit/utils.test.ts
+++ b/app/test/unit/utils.test.ts
@@ -1,3 +1,5 @@
+import {expect, describe, it} from '@jest/globals';
+
 import {
     sanitized,
     serializeCookies,

--- a/app/test/unit/utils.test.ts
+++ b/app/test/unit/utils.test.ts
@@ -1,0 +1,83 @@
+import {
+    sanitized,
+    serializeCookies,
+    deserializeCookies,
+} from "../../src/lib/icloud/utils";
+import { Cookie } from "tough-cookie";
+
+describe("utils", () => {
+    it("sanitizes usernames", () => {
+        expect(sanitized("steve@apple.com")).toEqual("steveapplecom");
+        expect(sanitized("elon.musk@tesla.com")).toEqual("elonmuskteslacom");
+    });
+
+    it("serializes cookies", () => {
+        const now = new Date();
+        const expires = new Date(now.getTime() + 3600000);
+
+        const testCookie = new Cookie({
+            creation: now,
+            key: "hello",
+            value: "world",
+            domain: "icloud.com",
+            path: "/",
+            secure: true,
+            httpOnly: true,
+            expires,
+        });
+
+        const cookies: Array<Cookie> = [testCookie];
+
+        expect(serializeCookies(cookies)).toEqual(
+            JSON.stringify({
+                cookies: [
+                    {
+                        key: "hello",
+                        value: "world",
+                        expires: expires.toISOString(),
+                        domain: "icloud.com",
+                        path: "/",
+                        secure: true,
+                        httpOnly: true,
+                        creation: now.toISOString(),
+                    },
+                ],
+            })
+        );
+    });
+
+    it("deserializes cookies", () => {
+        const now = new Date();
+        const expires = new Date(now.getTime() + 3600000);
+
+        const testCookie = new Cookie({
+            creation: now,
+            key: "hello",
+            value: "world",
+            domain: "icloud.com",
+            path: "/",
+            secure: true,
+            httpOnly: true,
+            expires,
+        });
+
+        expect(
+            deserializeCookies(
+                JSON.stringify({
+                    cookies: [
+                        {
+                            key: "hello",
+                            value: "world",
+                            expires: expires.toISOString(),
+                            domain: "icloud.com",
+                            path: "/",
+                            secure: true,
+                            httpOnly: true,
+                            creation: now.toISOString(),
+                        },
+                    ],
+                })
+            )
+        ).toEqual([testCookie]);
+    });
+});


### PR DESCRIPTION
This PR persists cookies to disk so that the session can be resumed on subsequent runs.  It is the equivalent of clicking the "Trust" button when signing in to icloud.com.  This prevents repeat email notifications about signing into icloud like this as well:

![screenshot-2023-04-05-195949@2x](https://user-images.githubusercontent.com/427213/230253698-66b538a6-cd12-49a5-aef7-d8d7e1ff7da7.png)
