### PR TITLE
Zone Selection on CLI

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -65,7 +65,7 @@
                 "--runInBand",
                 "--config", "jest.config.json",
                 //"--detectOpenHandles",
-                "test/unit/resources.network-manager.test.ts"
+                "app/test/unit/sync-engine.test.ts"
             ],
             "env": {
                 "NODE_NO_WARNINGS": "1"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,4 +86,5 @@
     "githubIssues.useBranchForIssues": "off",
     "githubIssues.workingIssueFormatScm": "fix: ${issueTitle} \n\nFixes ${issueNumberLabel}",
     "liveServer.settings.donotShowInfoMsg": true,
+    "eslint.options": { "overrideConfigFile": "./app/eslint.config.json" }
 }

--- a/app/src/app/factory.ts
+++ b/app/src/app/factory.ts
@@ -1,9 +1,9 @@
-import {Command, Option, InvalidArgumentError, CommanderError} from "commander";
+import { Command, CommanderError, InvalidArgumentError, Option } from "commander";
 import Cron from "croner";
-import {TokenApp, SyncApp, ArchiveApp, iCPSApp, DaemonApp} from "./icloud-app.js";
-import {Resources} from "../lib/resources/main.js";
-import {LogLevel} from "./event/log.js";
 import inquirer from "inquirer";
+import { Resources } from "../lib/resources/main.js";
+import { LogLevel } from "./event/log.js";
+import { ArchiveApp, DaemonApp, iCPSApp, SyncApp, TokenApp } from "./icloud-app.js";
 
 /**
  * This function can be used as a commander argParser. It will try to parse the value as a positive integer and throw an invalid argument error in case it fails
@@ -110,6 +110,7 @@ export type iCPSAppOptions = {
     username: string,
     password: string,
     trustToken?: string,
+    library: Resources.Types.ZoneOptions,
     dataDir: string,
     port: number,
     maxRetries: number,
@@ -156,6 +157,10 @@ export function argParser(callback: (res: iCPSApp) => void): Command {
             .makeOptionMandatory(false))
         .addOption(new Option(`-T, --trust-token <string>`, `The trust token for authentication. If not provided, the trust token is read from the \`.icloud-photos-sync\` resource file in data dir. If no stored trust token could be loaded, a new trust token will be acquired (requiring the input of an MFA code).`)
             .env(`TRUST_TOKEN`))
+        .addOption(new Option(`-z, --z <string>`, `Zone to sync.`)
+            .env(`ZONE`)
+            .choices(Object.values(Resources.Types.ZoneOptions))
+            .default(Resources.Types.ZoneOptions))
         .addOption(new Option(`-d, --data-dir <string>`, `Directory to store local copy of library.`)
             .env(`DATA_DIR`)
             .default(`/opt/icloud-photos-library`))

--- a/app/src/lib/resources/main.ts
+++ b/app/src/lib/resources/main.ts
@@ -1,12 +1,12 @@
 import PackageData from '../../../package.json' assert { type: 'json' }; // eslint-disable-line
-import {RESOURCES_ERR} from "../../app/error/error-codes.js";
-import {iCPSError} from "../../app/error/error.js";
-import {iCPSAppOptions} from "../../app/factory.js";
-import {EventManager, ListenerFunction} from "./event-manager.js";
-import {iCPSEvent, iCPSEventLog} from "./events-types.js";
-import {NetworkManager} from "./network-manager.js";
-import {ResourceManager} from "./resource-manager.js";
-import {Validator} from "./validator.js";
+import { RESOURCES_ERR } from "../../app/error/error-codes.js";
+import { iCPSError } from "../../app/error/error.js";
+import { iCPSAppOptions } from "../../app/factory.js";
+import { EventManager, ListenerFunction } from "./event-manager.js";
+import { iCPSEvent, iCPSEventLog } from "./events-types.js";
+import { NetworkManager } from "./network-manager.js";
+import { ResourceManager } from "./resource-manager.js";
+import { Validator } from "./validator.js";
 
 /**
  * This namespace handles the static access to the singleton functions of the ResourceManager, NetworkManager, Validator and EventManager
@@ -299,6 +299,24 @@ export namespace Resources {
          * Will use icloud.com.cn
          */
         CHINA = `china`,
+       }
+
+       /**
+        * Possible libraries to sync
+        */
+       export enum ZoneOptions {
+         /**
+          * Only sync the personal library
+          */
+         Primary = `personal`,
+         /**
+          * Only sync the shared library
+          */
+         Shared = `shared`,
+         /**
+          * Sync both libraries
+          */
+         Both = `both`
        }
    }
 }

--- a/app/src/lib/resources/resource-manager.ts
+++ b/app/src/lib/resources/resource-manager.ts
@@ -1,14 +1,14 @@
-import {iCPSError} from "../../app/error/error.js";
-import {RESOURCES_ERR} from "../../app/error/error-codes.js";
-import {iCPSAppOptions} from "../../app/factory.js";
-import * as PHOTOS_LIBRARY from '../photos-library/constants.js';
+import { readFileSync, writeFileSync } from "fs";
+import { jsonc } from "jsonc";
 import * as path from 'path';
-import {readFileSync, writeFileSync} from "fs";
-import {FILE_ENCODING, HAR_FILE_NAME, LIBRARY_LOCK_FILE_NAME, LOG_FILE_NAME, METRICS_FILE_NAME, PhotosAccountZone, RESOURCE_FILE_NAME, ResourceFile, iCPSResources} from "./resource-types.js";
-import {LogLevel} from "../../app/event/log.js";
-import {Resources} from "./main.js";
-import {iCPSEventRuntimeWarning} from "./events-types.js";
-import {jsonc} from "jsonc";
+import { RESOURCES_ERR } from "../../app/error/error-codes.js";
+import { iCPSError } from "../../app/error/error.js";
+import { LogLevel } from "../../app/event/log.js";
+import { iCPSAppOptions } from "../../app/factory.js";
+import * as PHOTOS_LIBRARY from '../photos-library/constants.js';
+import { iCPSEventRuntimeWarning } from "./events-types.js";
+import { Resources } from "./main.js";
+import { FILE_ENCODING, HAR_FILE_NAME, LIBRARY_LOCK_FILE_NAME, LOG_FILE_NAME, METRICS_FILE_NAME, PhotosAccountZone, RESOURCE_FILE_NAME, ResourceFile, iCPSResources } from "./resource-types.js";
 
 /**
  * This class handles access to the .icloud-photos-sync resource file and handles currently applied configurations from the CLI and environment variables
@@ -72,6 +72,10 @@ export class ResourceManager {
             Resources.emit(iCPSEventRuntimeWarning.RESOURCE_FILE_ERROR,
                 new iCPSError(RESOURCES_ERR.UNABLE_TO_WRITE_FILE).addCause(err));
         }
+    }
+
+    get zone(): Resources.Types.ZoneOptions {
+        return this._resources.library;
     }
 
     /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/steilerDev/icloud-photos-sync/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
ICPS will always download all assets of both zones.

Issue Number: #586 


## What is the new behavior?

Zones to download the asset from can be selected using an option on the CLI. Existing behaviour is the default.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information