### PR TITLE
fix(test): revert test workaround for bug in mock-fs

### DIFF
--- a/app/test/unit/photos-library.test.ts
+++ b/app/test/unit/photos-library.test.ts
@@ -289,7 +289,7 @@ describe(`Load state`, () => {
                 [Config.defaultConfig.dataDir]: {
                     [`.${orphanedAlbumUUID}`]: {},
                     [orphanedAlbumName]: mockfs.symlink({
-                        path: `${Config.defaultConfig.dataDir}/.${orphanedAlbumUUID}`,
+                        path: `.${orphanedAlbumUUID}`,
                     }),
                 },
             });


### PR DESCRIPTION
is no longer needed because broken 'exists' handling in mock-fs was fixed in v5.5.0

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/steilerDev/icloud-photos-sync/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
In #611 I added a workaround to one test in `photo-library.test.ts`, because mock-fs seemed to be unable to handle `exists` checks on symlinks with relative paths correctly. The workaround was to provide an absolute path for the symlink instead. However 5.5.0 was adopted within #611 already which included a fix for this bug.

## What is the new behavior?
The workaround (providing an absolute path) has been removed, as this does not correspond to what the app is actually working with. The symlink path is relative again.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information