### PR TITLE
Fixed docker-compose example's cron schedule

### DIFF
--- a/docs/src/get-started.md
+++ b/docs/src/get-started.md
@@ -30,7 +30,7 @@ The `latest` tag should always represent the latest stable release, whereas the 
               APPLE_ID_USER: "<iCloud Username>"
               APPLE_ID_PWD: "<iCloud Password>"
               TZ: "Europe/Berlin"                                                       
-              SCHEDULE: "* 2 * * *"
+              SCHEDULE: "0 2 * * *"
               ENABLE_CRASH_REPORTING: true
             volumes:
               - <photos-dir>:/opt/icloud-photos-library


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/steilerDev/icloud-photos-sync/blob/main/CONTRIBUTING.md#commit
- [n.a.] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Current documentation has an example for a docker-compose file that includes a cron schedule that tries to sync every minute of hour two, leading to a couple of dozen login warnings from Apple (and a couple of healthcheck.io warnings if signed up there)

## What is the new behavior?
Fixed the typo so the cron schedule is not every minute in hour 2, but once at 2:00

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information