### PR TITLE
docs: Use single quotation marks for curl commands in Get Started docs

### DIFF
--- a/docs/src/get-started.md
+++ b/docs/src/get-started.md
@@ -181,7 +181,7 @@ The MFA code can be entered through the exposed API:
         Submitting code `123456` using a CLI tool for making network requests, e.g. `curl`:
 
         ```
-        curl -X POST localhost:80/mfa?code=123456
+        curl -X POST 'localhost:80/mfa?code=123456'
         ```
 
     === "From Source"
@@ -222,7 +222,7 @@ This can be requested using the exposed API:
         Resending MFA code using `sms` to phone with number ID `2` using a CLI tool for making network requests, e.g. `curl`:
 
         ```
-        curl -X POST localhost:80/resend_mfa?method=sms&phoneNumberId=2
+        curl -X POST 'localhost:80/resend_mfa?method=sms&phoneNumberId=2'
         ```
 
     === "From Source"


### PR DESCRIPTION
in zsh/fish, `?` is treated as a glob and errors with "no matches found" if it doesn’t resolve. bash is different; it leaves unmatched globs unchanged, so the command seemed to work. quoting the URL ensures the literal string is passed consistently across different shells.

this doesn't work in zsh/fish:
```sh
% curl -X POST localhost:80/mfa?code=123456
zsh: no matches found: localhost:80/mfa?code=123456
```

but it works in bash:
```sh
bash-5.2$  curl -X POST localhost:80/mfa?code=123456
HTTP/1.1 200 OK
Content-Type: application/json
Date: Thu, 02 Oct 2025 06:14:47 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{
    "message": "Read MFA code: 123456"
}
```

but this works in both:
```sh
% curl -X POST 'localhost:80/mfa?code=123456'
HTTP/1.1 200 OK
Content-Type: application/json
Date: Thu, 02 Oct 2025 06:14:47 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Transfer-Encoding: chunked

{
    "message": "Read MFA code: 123456"
}
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/steilerDev/icloud-photos-sync/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information