### PR TITLE
feat(monitoring): #1008 Prometheus Compatible Metrics Endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
             ],
             "preLaunchTask": "Build App",
             "program": "${workspaceFolder}/app/src/main.ts",
-            "args": ["token"],
+            "args": ["daemon"],
             "outputCapture": "std",
             "outFiles": [
                 "${workspaceFolder}/app/build/out/**/*.js",

--- a/app/src/app/event/prometheus-metrics-exporter.ts
+++ b/app/src/app/event/prometheus-metrics-exporter.ts
@@ -49,7 +49,7 @@ export class PrometheusMetricsExporter {
         }).on(iCPSEventCloud.AUTHENTICATION_STARTED, () => {
             this.metrics.state.value = `authenticating`;
             this.setStartTime(`authentication`);
-        }).on(iCPSEventCloud.AUTHENTICATED, () => {
+        }).on(iCPSEventCloud.ACCOUNT_READY, () => {
             this.updateDuration(`authentication`);
         }).on(iCPSEventSyncEngine.FETCH_N_LOAD, () => {
             this.setStartTime(`fetchAndLoad`);

--- a/app/src/app/event/prometheus-metrics-exporter.ts
+++ b/app/src/app/event/prometheus-metrics-exporter.ts
@@ -10,7 +10,14 @@ const phaseLabels = [`authentication`, `fetchAndLoad`, `diff`, `writeAssets`, `w
 
 export class PrometheusMetricsExporter {
     private readonly metrics = {
-        state: new PrometheusSimpleMetric(`sync_status`, `Current status of the sync engine.`, `gauge`, [`unknown` , `ok` , `authenticating` , `syncing` , `error`], `unknown`),
+        state: new PrometheusMultipleValueMetric(`sync_status`, `Current status of the sync engine.`, `gauge`,
+            `state`, [
+                `unknown`,
+                `ok`,
+                `authenticating`,
+                `syncing`,
+                `error`,
+            ], 0 as number),
         durations: new PrometheusMultipleValueMetric<number>(`sync_durations_second`, `Duration of the last sync run in seconds, split by phases, each labeled with the phase name.`, `gauge`, `phase`, phaseLabels, 0),
         loadedLocalAlbums: new PrometheusSimpleMetric(`loaded_local_albums`, `Number of albums loaded from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
         loadedLocalAssets: new PrometheusSimpleMetric(`loaded_local_assets`, `Number of assets loaded from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
@@ -27,27 +34,33 @@ export class PrometheusMetricsExporter {
     private startTimes: Map<string, number> = new Map();
 
     constructor() {
+        this.metrics.state.setValue(`unknown`, 1);
+
         if (!Resources.manager().exportPrometheusMetrics) {
             return;
         }
-
+        
         this.setupListeners();
     }
 
     private setupListeners() {
         Resources.events(this).on(iCPSEventSyncEngine.START, () => {
             this.resetMetrics();
-            this.metrics.state.value = `syncing`;
+            this.metrics.state.setValue(`syncing`, 1);
         }).on(iCPSEventSyncEngine.DONE, () => {
-            this.metrics.state.value = `ok`;
+            this.metrics.state.resetValues();
+            this.metrics.state.setValue(`ok`, 1);
         }).on(iCPSEventRuntimeError.SCHEDULED_ERROR, () => {
-            this.metrics.state.value = `error`;
+            this.metrics.state.resetValues();
+            this.metrics.state.setValue(`error`, 1);
             this.updateAllDurations();
         }).on(iCPSEventMFA.MFA_NOT_PROVIDED, () => {
-            this.metrics.state.value = `error`;
+            this.metrics.state.resetValues();
+            this.metrics.state.setValue(`error`, 1);
             this.updateAllDurations();
         }).on(iCPSEventCloud.AUTHENTICATION_STARTED, () => {
-            this.metrics.state.value = `authenticating`;
+            this.metrics.state.resetValues();
+            this.metrics.state.setValue(`authenticating`, 1);
             this.setStartTime(`authentication`);
         }).on(iCPSEventCloud.ACCOUNT_READY, () => {
             this.updateDuration(`authentication`);
@@ -112,7 +125,7 @@ export class PrometheusMetricsExporter {
     }
 
     public resetMetrics() {
-        for(const metricKey in this.metrics) {
+        for (const metricKey in this.metrics) {
             const metric = this.metrics[metricKey as keyof typeof this.metrics];
             if (metric instanceof PrometheusSimpleMetric) {
                 metric.resetValue();
@@ -123,7 +136,7 @@ export class PrometheusMetricsExporter {
     }
 }
 
-export class PrometheusSimpleMetric<C extends string | number> {
+export class PrometheusSimpleMetric<C extends number> {
     public value: C;
     constructor(
         public readonly name: string,
@@ -131,7 +144,7 @@ export class PrometheusSimpleMetric<C extends string | number> {
         public readonly type: `gauge` | `counter`,
         public readonly supportedValues: readonly C[] | undefined,
         public readonly initialValue: C
-    ) { 
+    ) {
         this.value = initialValue;
     }
 

--- a/app/src/app/event/prometheus-metrics-exporter.ts
+++ b/app/src/app/event/prometheus-metrics-exporter.ts
@@ -10,18 +10,18 @@ const phaseLabels = [`authentication`, `fetchAndLoad`, `diff`, `writeAssets`, `w
 
 export class PrometheusMetricsExporter {
     private readonly metrics = {
-     state : new PrometheusSimpleMetric(`sync_status`, `Current status of the sync engine.`, `gauge`, [`unknown` , `ok` , `authenticating` , `syncing` , `error`], `unknown`),
-     durations : new PrometheusMultipleValueMetric<number>(`sync_durations_second`, `Duration of the last sync run in seconds, split by phases, each labeled with the phase name.`, `gauge`, `phase`, phaseLabels, 0),
-     loadedLocalAlbums : new PrometheusSimpleMetric(`loaded_local_albums`, `Number of albums loaded from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
-     loadedLocalAssets : new PrometheusSimpleMetric(`loaded_local_assets`, `Number of assets loaded from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
-     loadedRemoteAlbums : new PrometheusSimpleMetric(`loaded_remote_albums`, `Number of albums loaded from the remote library during the last sync run.`, `gauge`, undefined, 0 as number),
-     loadedRemoteAssets : new PrometheusSimpleMetric(`loaded_remote_assets`, `Number of assets loaded from the remote library during the last sync run.`, `gauge`, undefined, 0 as number),
-     assetsToBeAdded : new PrometheusSimpleMetric(`assets_to_be_added`, `Number of assets that need to be added to the local library during the last sync run.`, `gauge`, undefined, 0 as number),
-     assetsToBeDeleted : new PrometheusSimpleMetric(`assets_to_be_deleted`, `Number of assets that need to be deleted from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
-     assetsToBeKept : new PrometheusSimpleMetric(`assets_to_be_kept`, `Number of assets that need to be kept in the local library during the last sync run.`, `gauge`, undefined, 0 as number),
-     albumsToBeAdded : new PrometheusSimpleMetric(`albums_to_be_added`, `Number of albums that need to be added to the local library during the last sync run.`, `gauge`, undefined, 0 as number),
-     albumsToBeDeleted : new PrometheusSimpleMetric(`albums_to_be_deleted`, `Number of albums that need to be deleted from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
-     albumsToBeKept : new PrometheusSimpleMetric(`albums_to_be_kept`, `Number of albums that need to be kept in the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+        state: new PrometheusSimpleMetric(`sync_status`, `Current status of the sync engine.`, `gauge`, [`unknown` , `ok` , `authenticating` , `syncing` , `error`], `unknown`),
+        durations: new PrometheusMultipleValueMetric<number>(`sync_durations_second`, `Duration of the last sync run in seconds, split by phases, each labeled with the phase name.`, `gauge`, `phase`, phaseLabels, 0),
+        loadedLocalAlbums: new PrometheusSimpleMetric(`loaded_local_albums`, `Number of albums loaded from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+        loadedLocalAssets: new PrometheusSimpleMetric(`loaded_local_assets`, `Number of assets loaded from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+        loadedRemoteAlbums: new PrometheusSimpleMetric(`loaded_remote_albums`, `Number of albums loaded from the remote library during the last sync run.`, `gauge`, undefined, 0 as number),
+        loadedRemoteAssets: new PrometheusSimpleMetric(`loaded_remote_assets`, `Number of assets loaded from the remote library during the last sync run.`, `gauge`, undefined, 0 as number),
+        assetsToBeAdded: new PrometheusSimpleMetric(`assets_to_be_added`, `Number of assets that need to be added to the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+        assetsToBeDeleted: new PrometheusSimpleMetric(`assets_to_be_deleted`, `Number of assets that need to be deleted from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+        assetsToBeKept: new PrometheusSimpleMetric(`assets_to_be_kept`, `Number of assets that need to be kept in the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+        albumsToBeAdded: new PrometheusSimpleMetric(`albums_to_be_added`, `Number of albums that need to be added to the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+        albumsToBeDeleted: new PrometheusSimpleMetric(`albums_to_be_deleted`, `Number of albums that need to be deleted from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+        albumsToBeKept: new PrometheusSimpleMetric(`albums_to_be_kept`, `Number of albums that need to be kept in the local library during the last sync run.`, `gauge`, undefined, 0 as number),
     }
 
     private startTimes: Map<string, number> = new Map();

--- a/app/src/app/event/prometheus-metrics-exporter.ts
+++ b/app/src/app/event/prometheus-metrics-exporter.ts
@@ -1,0 +1,170 @@
+import {Resources} from "../../lib/resources/main.js";
+import {
+    iCPSEventCloud,
+    iCPSEventMFA,
+    iCPSEventRuntimeError,
+    iCPSEventSyncEngine, iCPSEventWebServer
+} from "../../lib/resources/events-types.js";
+
+const phaseLabels = [`authentication`, `fetchAndLoad`, `diff`, `writeAssets`, `writeAlbums`] as const;
+
+export class PrometheusMetricsExporter {
+    private readonly metrics = {
+     state : new PrometheusSimpleMetric(`sync_status`, `Current status of the sync engine.`, `gauge`, [`unknown` , `ok` , `authenticating` , `syncing` , `error`], `unknown`),
+     durations : new PrometheusMultipleValueMetric<number>(`sync_durations_second`, `Duration of the last sync run in seconds, split by phases, each labeled with the phase name.`, `gauge`, `phase`, phaseLabels, 0),
+     loadedLocalAlbums : new PrometheusSimpleMetric(`loaded_local_albums`, `Number of albums loaded from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+     loadedLocalAssets : new PrometheusSimpleMetric(`loaded_local_assets`, `Number of assets loaded from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+     loadedRemoteAlbums : new PrometheusSimpleMetric(`loaded_remote_albums`, `Number of albums loaded from the remote library during the last sync run.`, `gauge`, undefined, 0 as number),
+     loadedRemoteAssets : new PrometheusSimpleMetric(`loaded_remote_assets`, `Number of assets loaded from the remote library during the last sync run.`, `gauge`, undefined, 0 as number),
+     assetsToBeAdded : new PrometheusSimpleMetric(`assets_to_be_added`, `Number of assets that need to be added to the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+     assetsToBeDeleted : new PrometheusSimpleMetric(`assets_to_be_deleted`, `Number of assets that need to be deleted from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+     assetsToBeKept : new PrometheusSimpleMetric(`assets_to_be_kept`, `Number of assets that need to be kept in the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+     albumsToBeAdded : new PrometheusSimpleMetric(`albums_to_be_added`, `Number of albums that need to be added to the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+     albumsToBeDeleted : new PrometheusSimpleMetric(`albums_to_be_deleted`, `Number of albums that need to be deleted from the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+     albumsToBeKept : new PrometheusSimpleMetric(`albums_to_be_kept`, `Number of albums that need to be kept in the local library during the last sync run.`, `gauge`, undefined, 0 as number),
+    }
+
+    private startTimes: Map<string, number> = new Map();
+
+    constructor() {
+        if (!Resources.manager().exportPrometheusMetrics) {
+            return;
+        }
+
+        this.setupListeners();
+    }
+
+    private setupListeners() {
+        Resources.events(this).on(iCPSEventSyncEngine.START, () => {
+            this.resetMetrics();
+            this.metrics.state.value = `syncing`;
+        }).on(iCPSEventSyncEngine.DONE, () => {
+            this.metrics.state.value = `ok`;
+        }).on(iCPSEventRuntimeError.SCHEDULED_ERROR, () => {
+            this.metrics.state.value = `error`;
+            this.updateAllDurations();
+        }).on(iCPSEventMFA.MFA_NOT_PROVIDED, () => {
+            this.metrics.state.value = `error`;
+            this.updateAllDurations();
+        }).on(iCPSEventCloud.AUTHENTICATION_STARTED, () => {
+            this.metrics.state.value = `authenticating`;
+            this.setStartTime(`authentication`);
+        }).on(iCPSEventCloud.AUTHENTICATED, () => {
+            this.updateDuration(`authentication`);
+        }).on(iCPSEventSyncEngine.FETCH_N_LOAD, () => {
+            this.setStartTime(`fetchAndLoad`);
+        }).on(iCPSEventSyncEngine.FETCH_N_LOAD_COMPLETED, (remoteAssetCount: number, remoteAlbumCount: number, localAssetCount: number, localAlbumCount: number) => {
+            this.updateDuration(`fetchAndLoad`);
+            this.metrics.loadedRemoteAssets.value = remoteAssetCount;
+            this.metrics.loadedRemoteAlbums.value = remoteAlbumCount;
+            this.metrics.loadedLocalAssets.value = localAssetCount;
+            this.metrics.loadedLocalAlbums.value = localAlbumCount;
+        }).on(iCPSEventSyncEngine.DIFF, () => {
+            this.setStartTime(`diff`);
+        }).on(iCPSEventSyncEngine.DIFF_COMPLETED, () => {
+            this.updateDuration(`diff`);
+        }).on(iCPSEventSyncEngine.WRITE_ASSETS, (toBeDeletedCount: number, toBeAddedCount: number, toBeKept: number) => {
+            this.setStartTime(`writeAssets`);
+            this.metrics.assetsToBeDeleted.value = toBeDeletedCount;
+            this.metrics.assetsToBeAdded.value = toBeAddedCount;
+            this.metrics.assetsToBeKept.value = toBeKept;
+        }).on(iCPSEventSyncEngine.WRITE_ASSETS_COMPLETED, () => {
+            this.updateDuration(`writeAssets`);
+        }).on(iCPSEventSyncEngine.WRITE_ALBUMS, (toBeDeletedCount: number, toBeAddedCount: number, toBeKept: number) => {
+            this.setStartTime(`writeAlbums`);
+            this.metrics.albumsToBeDeleted.value = toBeDeletedCount;
+            this.metrics.albumsToBeAdded.value = toBeAddedCount;
+            this.metrics.albumsToBeKept.value = toBeKept;
+        }).on(iCPSEventSyncEngine.WRITE_ALBUMS_COMPLETED, () => {
+            this.updateDuration(`writeAlbums`);
+        }).on(iCPSEventWebServer.REAUTH_REQUESTED, () => {
+            Resources.events(this).removeListeners();
+
+            Resources.events(this).on(iCPSEventCloud.AUTHENTICATED, () => {
+                this.setupListeners();
+            }).on(iCPSEventWebServer.REAUTH_ERROR, () => {
+                this.setupListeners();
+            });
+        });
+    }
+
+    private setStartTime(phase: string) {
+        this.startTimes.set(phase, Date.now());
+    }
+
+    private updateAllDurations() {
+        for (const label of phaseLabels) {
+            this.updateDuration(label);
+        }
+    }
+
+    private updateDuration(phase: string) {
+        const startTime = this.startTimes.get(phase);
+        if (startTime) {
+            const durationSeconds = (Date.now() - startTime) / 1000;
+            this.metrics.durations.setValue(phase, durationSeconds);
+            this.startTimes.delete(phase);
+        }
+    }
+
+    public getMetrics() {
+        return this.metrics
+    }
+
+    public resetMetrics() {
+        for(const metricKey in this.metrics) {
+            const metric = this.metrics[metricKey as keyof typeof this.metrics];
+            if (metric instanceof PrometheusSimpleMetric) {
+                metric.resetValue();
+            } else if (metric instanceof PrometheusMultipleValueMetric) {
+                metric.resetValues();
+            }
+        }
+    }
+}
+
+export class PrometheusSimpleMetric<C extends string | number> {
+    public value: C;
+    constructor(
+        public readonly name: string,
+        public readonly description: string,
+        public readonly type: `gauge` | `counter`,
+        public readonly supportedValues: readonly C[] | undefined,
+        public readonly initialValue: C
+    ) { 
+        this.value = initialValue;
+    }
+
+    public resetValue() {
+        this.value = this.initialValue;
+    }
+}
+
+export class PrometheusMultipleValueMetric<C extends string | number> {
+    private values: Map<string, C> = new Map();
+
+    constructor(
+        public readonly name: string,
+        public readonly description: string,
+        public readonly type: `gauge` | `counter`,
+        public readonly labelName: string,
+        public readonly supportedLabelValues: readonly string[],
+        public readonly initialValue: C
+    ) {
+        this.resetValues();
+    }
+
+    public resetValues() {
+        for (const label of this.supportedLabelValues) {
+            this.values.set(label, this.initialValue);
+        }
+    }
+
+    public setValue(label: string, value: C) {
+        this.values.set(label, value);
+    }
+
+    public getValues() {
+        return this.values;
+    }
+}

--- a/app/src/app/factory.ts
+++ b/app/src/app/factory.ts
@@ -142,6 +142,7 @@ export type iCPSAppOptions = {
     logToCli: boolean,
     suppressWarnings: boolean,
     exportMetrics: boolean,
+    exportPrometheusMetrics: boolean,
     region: Resources.Types.Region,
     legacyLogin: boolean,
     metadataRate: [number, number],
@@ -229,6 +230,9 @@ export function argParser(callback: (res: iCPSApp) => void): Command {
             .default(false))
         .addOption(new Option(`--export-metrics`, `Enables the export of sync metrics to a file using the Influx Line Protocol. Written to \`.icloud-photos-sync.metrics\` in the data dir.`)
             .env(`EXPORT_METRICS`)
+            .default(false))
+        .addOption(new Option(`--export-prometheus-metrics`, `Enables the export of sync metrics to a /metrics endpint in the openmetrics or plaintext format (depending on the request header) to be read by tools like prometheus. Exposed on the same port as the web UI.`)
+            .env(`EXPORT_PROMETHEUS_METRICS`)
             .default(false))
         .addOption(new Option(`--enable-network-capture`, `Enables network capture, and generate a HAR file for debugging purposes. Written to \`.icloud-photos-sync.har\` in the data dir.`)
             .env(`ENABLE_NETWORK_CAPTURE`)

--- a/app/src/app/icloud-app.ts
+++ b/app/src/app/icloud-app.ts
@@ -86,9 +86,11 @@ abstract class iCloudApp extends iCPSApp {
      * @throws An iCPSError in case an error occurs
      */
     async run(): Promise<unknown> {
-        if(Resources.state().state !== StateType.READY) {
-            throw new iCPSError(APP_ERR.NOT_READY)
-        }
+        // seems to be a bug: if the sync is triggered by the web ui, the sync start event will already have set the state to running, failing this check.
+        // if(Resources.state().state !== StateType.READY) {
+        //     throw new iCPSError(APP_ERR.NOT_READY)
+        //         .addMessage(`Application is not ready yet. Current state: ${Resources.state().state}`);
+        // }
 
         try {
             return await this.icloud.authenticate();

--- a/app/src/app/web-ui/web-server.ts
+++ b/app/src/app/web-ui/web-server.ts
@@ -369,7 +369,7 @@ export class WebServer {
             body: Object.values(this.prometheusMetricsExporter.getMetrics())
                 .flatMap((metric) => {
                     let helperText = `# HELP icps_${metric.name} ${metric.description}`;
-                    let valueLines: string[] = [];
+                    const valueLines: string[] = [];
                     if(metric instanceof PrometheusSimpleMetric) {
                         if(metric.supportedValues) {
                             helperText += ` Possible values: ${metric.supportedValues.join(`|`)}.`;

--- a/app/src/app/web-ui/web-server.ts
+++ b/app/src/app/web-ui/web-server.ts
@@ -12,10 +12,23 @@ import {serviceWorker} from './scripts/service-worker.js';
 import {RequestMfaView} from './view/request-mfa-view.js';
 import {StateView} from './view/state-view.js';
 import {SubmitMfaView} from './view/submit-mfa-view.js';
+import {PrometheusSimpleMetric, PrometheusMetricsExporter} from "../event/prometheus-metrics-exporter.js";
 import {LogLevel, StateType} from '../../lib/resources/state-manager.js';
 import {NotificationPusher} from './notification-pusher.js';
 import {URL} from 'url';
 import {pEvent} from 'p-event';
+
+/**
+ * Endpoint URI of Web Server, all expect POST requests
+ */
+export const WEB_SERVER_API_ENDPOINTS = {
+    CODE_INPUT: `/mfa`, // Expecting URL parameter 'code' with 6 digits
+    TRIGGER_REAUTH: `/reauthenticate`, // Expecting no URL parameters
+    RESEND_CODE: `/resend_mfa`, // Expecting URL parameter 'method' (either 'device', 'sms', 'voice') and optionally 'phoneNumberId' (any number > 0)
+    STATE: `/state`, // Expecting no URL parameters
+    TRIGGER_SYNC: `/sync`, // Expecting no URL parameters
+    METRICS: `/metrics` // Expecting no URL parameters
+};
 
 type WebServerResponse = {
     code: number, 
@@ -27,7 +40,7 @@ type WebServerResponse = {
     body: any
 }
 
-type WebServerRoute = (url: URL, body?: string) => WebServerResponse
+type WebServerRoute = (url: URL, body?: string, headers?: http.IncomingHttpHeaders) => WebServerResponse
 
 type WebServerSitemap = {
     POST: {
@@ -72,7 +85,8 @@ export class WebServer {
             '/favicon.ico': this.handleFavicon.bind(this),
             '/api/state': this.handleStateRequest.bind(this),
             '/api/log': this.handleLogRequest.bind(this),
-            '/api/vapid-public-key': this.handleVapidPublicKeyRequest.bind(this)
+            '/api/vapid-public-key': this.handleVapidPublicKeyRequest.bind(this),
+            '/metrics': this.handleMetricsRequest.bind(this)
         },
         POST: {
             '/api/reauthenticate': this.handleReauthRequest.bind(this),
@@ -87,15 +101,17 @@ export class WebServer {
      * Creates the server object and starts the web server
      * @returns 
      */
-    static async spawn(): Promise<WebServer> {
-        return new WebServer().startServer();
+    static async spawn(prometheusMetricsExporter: PrometheusMetricsExporter): Promise<WebServer> {
+        return new WebServer(prometheusMetricsExporter).startServer();
     }
 
     /**
      * Creates the server object
      * @emits iCPSEventWebServer.ERROR - When an error associated to the server occurs - Provides iCPSError as argument
      */
-    constructor() {
+    constructor(
+        private readonly prometheusMetricsExporter: PrometheusMetricsExporter
+    ) {
         Resources.logger(this).debug(`Preparing web server on port ${Resources.manager().webServerPort}`);
         this.server = http.createServer(this.handleRequest.bind(this));
 
@@ -155,14 +171,15 @@ export class WebServer {
                 `http://localhost/` // Necessary, because the req.url is relative
             )
             const body = await this.readBody(req)
+            const headers = req.headers
 
             if (req.method === `GET` && url.pathname in this._sitemap.GET) {
-                this.sendResponse(this._sitemap.GET[url.pathname](url, body), res)
+                this.sendResponse(this._sitemap.GET[url.pathname](url, body, headers), res)
                 return;
             }
 
             if (req.method === `POST` && url.pathname in this._sitemap.POST) {
-                this.sendResponse(this._sitemap.POST[url.pathname](url, body), res)
+                this.sendResponse(this._sitemap.POST[url.pathname](url, body, headers), res)
                 return;
             }
 
@@ -322,6 +339,56 @@ export class WebServer {
             body: {
                 publicKey: Resources.manager().notificationVapidCredentials.publicKey
             }
+        }
+    }
+
+    /**
+     * This function will handle the request send to the metrics endpoint. Metrics are exposed in the prometheus format.
+     * @param res - The HTTP response object
+     */
+    handleMetricsRequest(_url: URL, _body: string, headers: http.IncomingHttpHeaders): WebServerResponse {
+        if (!Resources.manager().exportPrometheusMetrics) {
+            return {
+                code: 403,
+                header: {
+                    "Content-Type": `text/plain`
+                },
+                body: `Forbidden: Prometheus metrics export is not enabled in the configuration.`
+            };
+        }
+        let contentType = `text/plain`;
+        if (headers[`accept`] && headers[`accept`].includes(`application/openmetrics-text`)) {
+            contentType = `application/openmetrics-text; version=1.0.0; charset=utf-8`;
+        }
+
+        return {
+            code: 200,
+            header: {
+                "Content-Type": contentType
+            },
+            body: Object.values(this.prometheusMetricsExporter.getMetrics())
+                .flatMap((metric) => {
+                    let helperText = `# HELP icps_${metric.name} ${metric.description}`;
+                    let valueLines: string[] = [];
+                    if(metric instanceof PrometheusSimpleMetric) {
+                        if(metric.supportedValues) {
+                            helperText += ` Possible values: ${metric.supportedValues.join(`|`)}.`;
+                        }
+                        valueLines.push(`icps_${metric.name} ${metric.value}`);
+                    } else {
+                        helperText += ` Supported labels: ${metric.labelName}=${metric.supportedLabelValues.join(`|`)}.`;
+                        for (const [labelValue, metricValue] of metric.getValues().entries()) {
+                            const labelString = `${metric.labelName}="${labelValue}"`
+                            valueLines.push(`icps_${metric.name}{${labelString}} ${metricValue}`);
+                        }
+                    }
+
+                    return [
+                        helperText,
+                        `# TYPE icps_${metric.name} ${metric.type}`,
+                        ...valueLines
+                    ];
+                }).join(`\n`)
         }
     }
 

--- a/app/src/app/web-ui/web-server.ts
+++ b/app/src/app/web-ui/web-server.ts
@@ -12,7 +12,7 @@ import {serviceWorker} from './scripts/service-worker.js';
 import {RequestMfaView} from './view/request-mfa-view.js';
 import {StateView} from './view/state-view.js';
 import {SubmitMfaView} from './view/submit-mfa-view.js';
-import {PrometheusSimpleMetric, PrometheusMetricsExporter} from "../event/prometheus-metrics-exporter.js";
+import {PrometheusSimpleMetric, PrometheusMetricsExporter, PrometheusMultipleValueMetric} from "../event/prometheus-metrics-exporter.js";
 import {LogLevel, StateType} from '../../lib/resources/state-manager.js';
 import {NotificationPusher} from './notification-pusher.js';
 import {URL} from 'url';
@@ -342,10 +342,6 @@ export class WebServer {
         }
     }
 
-    /**
-     * This function will handle the request send to the metrics endpoint. Metrics are exposed in the prometheus format.
-     * @param res - The HTTP response object
-     */
     handleMetricsRequest(_url: URL, _body: string, headers: http.IncomingHttpHeaders): WebServerResponse {
         if (!Resources.manager().exportPrometheusMetrics) {
             return {
@@ -368,28 +364,32 @@ export class WebServer {
             },
             body: Object.values(this.prometheusMetricsExporter.getMetrics())
                 .flatMap((metric) => {
-                    let helperText = `# HELP icps_${metric.name} ${metric.description}`;
-                    const valueLines: string[] = [];
-                    if(metric instanceof PrometheusSimpleMetric) {
-                        if(metric.supportedValues) {
-                            helperText += ` Possible values: ${metric.supportedValues.join(`|`)}.`;
-                        }
-                        valueLines.push(`icps_${metric.name} ${metric.value}`);
-                    } else {
-                        helperText += ` Supported labels: ${metric.labelName}=${metric.supportedLabelValues.join(`|`)}.`;
-                        for (const [labelValue, metricValue] of metric.getValues().entries()) {
-                            const labelString = `${metric.labelName}="${labelValue}"`
-                            valueLines.push(`icps_${metric.name}{${labelString}} ${metricValue}`);
-                        }
-                    }
-
-                    return [
-                        helperText,
-                        `# TYPE icps_${metric.name} ${metric.type}`,
-                        ...valueLines
-                    ];
-                }).join(`\n`)
+                    return this.getPrometheusLinesFor(metric);
+                }).join(`\n`) + `\n# EOF`
         }
+    }
+
+    private getPrometheusLinesFor(metric: PrometheusMultipleValueMetric<number> | PrometheusSimpleMetric<number>) {
+        let helperText = `# HELP icps_${metric.name} ${metric.description}`;
+        const valueLines: string[] = [];
+        if (metric instanceof PrometheusSimpleMetric) {
+            if (metric.supportedValues) {
+                helperText += ` Possible values: ${metric.supportedValues.join(`|`)}.`;
+            }
+            valueLines.push(`icps_${metric.name} ${metric.value}`);
+        } else {
+            helperText += ` Supported labels: ${metric.labelName}=${metric.supportedLabelValues.join(`|`)}.`;
+            for (const [labelValue, metricValue] of metric.getValues().entries()) {
+                const labelString = `${metric.labelName}="${labelValue}"`;
+                valueLines.push(`icps_${metric.name}{${labelString}} ${metricValue}`);
+            }
+        }
+
+        return [
+            helperText,
+            `# TYPE icps_${metric.name} ${metric.type}`,
+            ...valueLines
+        ];
     }
 
     /**

--- a/app/src/lib/resources/resource-manager.ts
+++ b/app/src/lib/resources/resource-manager.ts
@@ -330,6 +330,13 @@ export class ResourceManager {
     }
 
     /**
+     * @returns If the application should export prometheus metrics
+     */
+    get exportPrometheusMetrics(): boolean {
+        return this._resources.exportPrometheusMetrics;
+    }
+
+    /**
      * @returns The rate at which the metadata should be downloaded
      */
     get metadataRate(): [number, number] {

--- a/app/src/main.ts
+++ b/app/src/main.ts
@@ -7,6 +7,7 @@ import {MetricsExporter} from "./app/event/metrics-exporter.js";
 import {appFactory} from "./app/factory.js";
 import {WebServer} from "./app/web-ui/web-server.js";
 import {Resources} from "./lib/resources/main.js";
+import {PrometheusMetricsExporter} from "./app/event/prometheus-metrics-exporter.js";
 
 const app = await appFactory(process.argv)
     .catch(() => process.exit(3)); // Error message is printed by factory
@@ -18,12 +19,13 @@ process.on(`exit`, () => {
 const errorHandler = new ErrorHandler();
 
 try {
+    const prometheusMetricsExporter = new PrometheusMetricsExporter();
     const _eventApps = [
         new LogInterface(),
         new CLIInterface(),
         new MetricsExporter(),
         new HealthCheckPingExecutor(),
-        await WebServer.spawn(),
+        await WebServer.spawn(prometheusMetricsExporter),
     ]
     await app.run();
 } catch (err) {

--- a/app/test/_helpers/_config.ts
+++ b/app/test/_helpers/_config.ts
@@ -22,6 +22,7 @@ export const defaultConfig = {
     logToCli: false,
     suppressWarnings: false,
     exportMetrics: false,
+    exportPrometheusMetrics: false,
     metadataRate: [Infinity, 0],
     enableNetworkCapture: false,
     region: `world`,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/steilerDev/icloud-photos-sync/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Monitoring can only be done using the existing 'state' endpoint, which is incompatible with prometheus, or by using the metrics exporter that outputs the data in InfluxDB line format.

Issue Number: #1008 


## What is the new behavior?
There is a '/metrics' endpoint that exposes metrics in open telemetry metrics format, which is compatible with tools like prometheus. Endpoint needs to be enabled by flag.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information