### PR TITLE
fix: workaround iOS 26.4 MFA by switching default to SMS

### DIFF
--- a/app/src/app/web-ui/web-server.ts
+++ b/app/src/app/web-ui/web-server.ts
@@ -102,7 +102,6 @@ export class WebServer {
         // allow the process to exit, if this server is the only thing left running
         this.server.unref();
 
-        // Default MFA request always goes to device
         this.mfaMethod = new MFAMethod();
     }
 

--- a/app/src/lib/icloud/icloud.ts
+++ b/app/src/lib/icloud/icloud.ts
@@ -113,7 +113,7 @@ export class iCloud {
 
             if (response.status === 409) {
                 Resources.logger(this).debug(`Response status is 409, requiring MFA`);
-                const trustedPhoneNumbers = await this.getTrustedPhoneNumbers()
+                const trustedPhoneNumbers = await this.requestMFAViaSMS();
                 Resources.emit(iCPSEventCloud.MFA_REQUIRED, trustedPhoneNumbers);
                 return;
             }
@@ -228,6 +228,40 @@ export class iCloud {
             Resources.emit(iCPSEventRuntimeWarning.TRUSTED_PHONE_NUMBERS_ERROR, new iCPSError(MFA_ERR.NO_PHONE_NUMBERS).addCause(err));
         }
         return []
+    }
+
+    /**
+     * Requests an MFA code via SMS to the first trusted phone number.
+     * Required since iOS 26.4 where device push notifications no longer arrive for third-party auth.
+     * The SMS flow still works with legacy endpoints (PUT /verify/phone).
+     * The response contains the list of trusted phone numbers (since GET /auth now returns HTML).
+     * @returns The list of trusted phone numbers from the SMS request response
+     */
+    async requestMFAViaSMS(): Promise<TrustedPhoneNumber[]> {
+        try {
+            Resources.logger(this).info(`Requesting MFA code via SMS`);
+
+            const url = ENDPOINTS.AUTH.BASE + ENDPOINTS.AUTH.PATH.MFA.PHONE_RESEND;
+            const config: AxiosRequestConfig = {
+                validateStatus: status => status === 200,
+            };
+            const data = {
+                phoneNumber: {
+                    id: 1,
+                },
+                mode: `sms`,
+            };
+
+            const response = await Resources.network().put(url, data, config);
+            const validatedResponse = Resources.validator().validateResendMFAPhoneResponse(response);
+            Resources.logger(this).info(`Successfully requested MFA code via SMS to ${validatedResponse.data.trustedPhoneNumber.numberWithDialCode}`);
+
+            return validatedResponse.data.trustedPhoneNumbers ?? [];
+        } catch (err) {
+            Resources.logger(this).warn(`Failed to request MFA via SMS: ${err}`);
+        }
+
+        return [];
     }
 
     /**

--- a/app/src/lib/icloud/mfa/mfa-method.ts
+++ b/app/src/lib/icloud/mfa/mfa-method.ts
@@ -27,7 +27,7 @@ export class MFAMethod {
      * @param mfaMethod - The method to be used. Defaults to `device`
      * @param numberId - The number id used for sending sms or voice codes. Defaults to 1
      */
-    constructor(mfaMethod: `device` | `voice` | `sms` = `device`, numberId: number = 1) {
+    constructor(mfaMethod: `device` | `voice` | `sms` = `sms`, numberId: number = 1) {
         this.update(mfaMethod, numberId);
     }
 

--- a/app/src/lib/resources/network-manager.ts
+++ b/app/src/lib/resources/network-manager.ts
@@ -71,6 +71,10 @@ export class HeaderJar {
         this.setHeader(new Header(`idmsa.apple.com`, `X-Apple-OAuth-Response-Type`, `code`));
         this.setHeader(new Header(`idmsa.apple.com`, `X-Apple-OAuth-Response-Mode`, `web_message`));
         this.setHeader(new Header(`idmsa.apple.com`, `X-Apple-OAuth-Client-Type`, `firstPartyAuth`));
+        this.setHeader(new Header(`idmsa.apple.com`, `X-Apple-OAuth-Redirect-URI`, `https://www.icloud.com`));
+        this.setHeader(new Header(`idmsa.apple.com`, `X-Apple-OAuth-Require-Grant-Code`, `true`));
+        this.setHeader(new Header(`idmsa.apple.com`, `X-Apple-OAuth-State`, CLIENT_ID));
+        this.setHeader(new Header(`idmsa.apple.com`, `X-Apple-Offer-Security-Upgrade`, `1`));
 
         axios.interceptors.request.use(config => this._injectHeaders(config));
         axios.interceptors.response.use(response => this._extractHeaders(response));
@@ -109,6 +113,12 @@ export class HeaderJar {
         if (response.headers.scnt && this.isApplicable(response.config, new Header(`idmsa.apple.com`, ``, ``))) {
             Resources.logger(this).debug(`Extracted scnt from response header with length ` + response.headers.scnt.length);
             this.setHeader(new Header(`idmsa.apple.com`, HEADER_KEYS.SCNT, response.headers.scnt));
+        }
+
+        const authAttributes = response.headers[HEADER_KEYS.AUTH_ATTRIBUTES.toLowerCase()];
+        if (authAttributes && this.isApplicable(response.config, new Header(`idmsa.apple.com`, ``, ``))) {
+            Resources.logger(this).debug(`Extracted auth attributes from response header with length ` + authAttributes.length);
+            this.setHeader(new Header(`idmsa.apple.com`, HEADER_KEYS.AUTH_ATTRIBUTES, authAttributes));
         }
 
         if (response.headers[`set-cookie`] && Array.isArray(response.headers[`set-cookie`])) {
@@ -268,6 +278,7 @@ export class NetworkManager {
 
         this._headerJar.clearHeader(HEADER_KEYS.SCNT);
         this._headerJar.clearHeader(HEADER_KEYS.SESSION_ID);
+        this._headerJar.clearHeader(HEADER_KEYS.AUTH_ATTRIBUTES);
 
         await this.settleRateLimiter();
         await this.settleCCYLimiter();

--- a/app/src/lib/resources/network-types.ts
+++ b/app/src/lib/resources/network-types.ts
@@ -32,6 +32,7 @@ export const CLIENT_INFO = jsonc.stringify({
 export const HEADER_KEYS = {
     SCNT: `scnt`,
     SESSION_ID: `X-Apple-ID-Session-Id`,
+    AUTH_ATTRIBUTES: `X-Apple-Auth-Attributes`,
     COOKIE: `Cookie`,
 };
 

--- a/app/test/_helpers/_config.ts
+++ b/app/test/_helpers/_config.ts
@@ -93,5 +93,9 @@ export const REQUEST_HEADER = {
         'X-Apple-OAuth-Response-Type': `code`,
         'X-Apple-OAuth-Response-Mode': `web_message`,
         'X-Apple-OAuth-Client-Type': `firstPartyAuth`,
+        'X-Apple-OAuth-Redirect-URI': `https://www.icloud.com`,
+        'X-Apple-OAuth-Require-Grant-Code': `true`,
+        'X-Apple-OAuth-State': `d39ba9916b7251055b22c7f910e2ea796ee65e98b2ddecea8f5dde8d9d1a815d`,
+        'X-Apple-Offer-Security-Upgrade': `1`,
     },
 };

--- a/app/test/unit/icloud.test.ts
+++ b/app/test/unit/icloud.test.ts
@@ -200,7 +200,7 @@ describe.each([
         test(`Invalid Trust Token - MFA Required`, async () => {
             // ICloud.authenticate returns ready promise. Need to modify in order to resolve at the end of the test
             icloud.getReady = jest.fn<typeof icloud.getReady>().mockResolvedValue(true);
-            icloud.getTrustedPhoneNumbers = jest.fn<typeof icloud.getTrustedPhoneNumbers>().mockResolvedValue(`someVal` as any)
+            icloud.requestMFAViaSMS = jest.fn<typeof icloud.requestMFAViaSMS>().mockResolvedValue(`someVal` as any);
 
             const authenticationEvent = mockedEventManager.spyOnEvent(iCPSEventCloud.AUTHENTICATION_STARTED);
             const mfaEvent = mockedEventManager.spyOnEvent(iCPSEventCloud.MFA_REQUIRED);
@@ -216,7 +216,7 @@ describe.each([
 
             await icloud.authenticate();
 
-            expect(icloud.getTrustedPhoneNumbers).toHaveBeenCalled()
+            expect(icloud.requestMFAViaSMS).toHaveBeenCalled()
             expect(trustedEvent).not.toHaveBeenCalled();
             expect(authenticationEvent).toHaveBeenCalled();
             expect(mfaEvent).toHaveBeenCalledWith(`someVal`);

--- a/app/test/unit/resources.network-manager.test.ts
+++ b/app/test/unit/resources.network-manager.test.ts
@@ -24,7 +24,7 @@ describe(`HeaderJar`, () => {
         const axiosInstance = axios.create();
         const headerJar = new HeaderJar(axiosInstance);
 
-        expect(headerJar.headers.size).toBe(13);
+        expect(headerJar.headers.size).toBe(17);
         expect((axiosInstance.interceptors.request as any).handlers.length).toBe(1);
     });
 


### PR DESCRIPTION
## Summary
- Switches default MFA method from device-push to SMS as workaround for iOS 26.4 breaking device-push MFA
- Auto-requests SMS code after SRP auth returns 409
- Adds missing OAuth headers (`X-Apple-OAuth-Redirect-URI`, `X-Apple-OAuth-Require-Grant-Code`, `X-Apple-OAuth-State`, `X-Apple-Offer-Security-Upgrade`)
- Adds `X-Apple-Auth-Attributes` header extraction and echo (dynamic header like `scnt`)

## Context
Apple introduced a new caBLE v2-based bridge protocol for device-push MFA on icloud.com. The old `/verify/trusteddevice` endpoints no longer work on iOS 26.4+. The SMS flow via `/verify/phone` is unaffected and still works with legacy endpoints.

See #1007 for full investigation.

## Test plan
- [x] Unit tests pass (15/16 suites, 1 pre-existing timezone failure in web.test.ts)
- [x] Lint clean
- [ ] Live test: SRP login → auto SMS request → enter code → trust token acquired

🤖 Generated with [Claude Code](https://claude.com/claude-code)